### PR TITLE
set dummy BINANCE_API_* for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      BINANCE_API_KEY: dummy
+      BINANCE_API_SECRET: dummy
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
- Add "BINANCE_API_KEY" and"BINANCE_API_SECRET" dummy values in CI workflow
- Prevents import errors in tests when ".env" is missing